### PR TITLE
feat: `moodle:test`-Command und kleine Anpassung des Plugin-Pfades

### DIFF
--- a/modules/clone.toml
+++ b/modules/clone.toml
@@ -105,7 +105,11 @@ ref = "_clone $REPO_QUESTIONPY_DOCS ./questionpy/docs"
 ref = "_clone $REPO_QUESTIONPY_DOTGITHUB ./questionpy/dotgithub --branch $REPO_QUESTIONPY_DOTGITHUB_TAG"
 
 [tool.poe.tasks."_clone:ensure-repos:qtype"]
-ref = "_clone $REPO_MOODLE_QTYPE_QUESTIONPY ./questionpy/moodle-qtype"
+deps = ["_clone:ensure-repos:moodle:code"]
+sequence = [
+  "_clone $REPO_MOODLE_QTYPE_QUESTIONPY ./vendor/moodle/question/type/questionpy",
+  { cmd = "ln -sfn ${POE_ROOT}/vendor/moodle/question/type/questionpy ./questionpy/moodle-qtype" },
+]
 
 [tool.poe.tasks."_clone:ensure-repos:moodle"]
 sequence = [

--- a/modules/moodle.toml
+++ b/modules/moodle.toml
@@ -71,6 +71,27 @@ deps = [
 ]
 cmd = "./bin/moodle-docker-compose"
 
+### moodle:test
+
+[tool.poe.tasks."moodle:test"]
+help = "Run PHPUnit tests."
+cwd = "./vendor/moodle-docker"
+deps = [
+  "_clone:ensure-repos:moodle",
+  "_moodle:ensure-docker",
+  "_moodle:ensure-moodle-docker-running",
+  "_moodle:ensure-phpunit-initialised",
+  "_utils:msg moodle:test",
+]
+cmd = "./bin/moodle-docker-compose exec webserver vendor/bin/phpunit question/type/questionpy/tests/$source --test-suffix=_test.php"
+
+  [[tool.poe.tasks."moodle:test".args]]
+  name = "source"
+  positional = true
+  help = "Test file or directory relative to `moodle-qtype/tests/`."
+  default = "."
+
+
 ### private tasks
 
 # Patch webserver service
@@ -100,6 +121,24 @@ shell = """
   if ! $(docker info >/dev/null 2>&1); then
     echo -e "${COLOR_WARN}Docker daemon is not running!${COLOR_OFF}"
     exit 1
+  fi
+"""
+
+[tool.poe.tasks."_moodle:ensure-moodle-docker-running"]
+cwd = "./vendor/moodle-docker"
+shell = """
+  if ! $(./bin/moodle-docker-compose exec webserver echo >/dev/null 2>&1); then
+    echo -e "${COLOR_WARN}Moodle docker is not running!${COLOR_OFF}"
+    echo -e "${COLOR_WARN}Use ${COLOR_TASK}[moodle:start]${COLOR_WARN} to start the stack.${COLOR_OFF}"
+    exit 1
+  fi
+"""
+
+[tool.poe.tasks."_moodle:ensure-phpunit-initialised"]
+cwd = "./vendor/moodle-docker"
+shell = """
+  if ! $(./bin/moodle-docker-compose exec webserver vendor/bin/phpunit question/type/questionpy --list-tests >/dev/null 2>&1); then
+    ./bin/moodle-docker-compose exec -T webserver php admin/tool/phpunit/cli/init.php
   fi
 """
 

--- a/modules/moodle.toml
+++ b/modules/moodle.toml
@@ -86,9 +86,7 @@ shell = """
   services:
     webserver:
       extra_hosts:
-        - "host.docker.internal:host-gateway"
-      volumes:
-        - "${POE_ROOT}/questionpy/moodle-qtype:/var/www/html/question/type/questionpy"' > local.yml
+        - "host.docker.internal:host-gateway"' > local.yml
 """
 
 [tool.poe.tasks."_moodle:ensure-moodle-config"]


### PR DESCRIPTION
Mit `moodle:test <path>` können die Tests einer Datei oder eines ganzen Ordners ausgeführt werden. Sollte PHPUnit noch nicht initialisiert sein, geschieht das automatisch vor Ausführung der Tests. Wird kein Pfad angegeben, so werden alle Tests ausgeführt, da `<path>` als Default `.` ist.

Zusätzlich wird das Plugin nicht mehr direkt nach `qpy-dev/questionpy/moodle-qtype` gecloned, sondern direkt unter `qpy-dev/vendor/moodle/question/type/questionpy`. Anschließend wird ein Soft-Link von `qpy-dev/questionpy/moodle-qtype` zu diesem Ordner erstellt. Mit dieser Änderung lässt sich z.B. `grunt` ohne Umstände direkt ausführen.